### PR TITLE
Use an HTTPClient interface instead of *http.Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ const DefaultAPIURL = "https://api.statuspage.io/v1/pages/"
 type Client struct {
 	apiKey     string
 	pageID     string
-	httpClient *http.Client
+	httpClient HTTPClient
 	url        *url.URL
 }
 
@@ -28,4 +28,16 @@ func NewClient(apiKey, pageID string) (*Client, error) {
 		url:        u,
 	}
 	return &c, nil
+}
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func WithHTTPClient(c HTTPClient) func(*Client) error {
+
+	return func(client *Client) error {
+		client.httpClient = c
+		return nil
+	}
 }


### PR DESCRIPTION
The *http.Client is only used for the following method:
```
    Do(*http.Request)(*http.Response,error)
```

This poses problem when configuring to use a different http client such
as Hashicorp's retryablehttp.Client.