### PR TITLE
Add http client as an option

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ const DefaultAPIURL = "https://api.statuspage.io/v1/pages/"
 type Client struct {
 	apiKey     string
 	pageID     string
-	httpClient *http.Client
+	httpClient HTTPClient
 	url        *url.URL
 }
 
@@ -28,4 +28,13 @@ func NewClient(apiKey, pageID string) (*Client, error) {
 		url:        u,
 	}
 	return &c, nil
+}
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func WithHTTPClient(client *Client, c HTTPClient) error {
+	client.httpClient = c
+	return nil
 }


### PR DESCRIPTION
The client only uses the following *http.Client method:
```
    Do(*http.Request) (*http.Response, error)
```

Changed the client to an interface and added an option for people to use
the http client of their choice (e.g. retryablehttp, ...)